### PR TITLE
Refactor plan-review hook: extract helpers and reduce duplication

### DIFF
--- a/.claude/plan-review.jsonl
+++ b/.claude/plan-review.jsonl
@@ -1,8 +1,0 @@
-{"session_id":"93cd75b4-19bb-4497-bca4-14b3e309a6aa","file_path":"/Users/kaneshin/src/github.com/kaneshin/dotfiles/.claude/plans/inherited-exploring-coral.md","timestamp":1773421660}
-{"session_id":"3f99fc95-fca5-4abe-8cf0-18f88317ea59","file_path":"/Users/kaneshin/src/github.com/kaneshin/dotfiles/.claude/plans/cheeky-meandering-octopus.md","reviews":2,"timestamp":1773423698}
-{"session_id":"b9029222-71bc-4c8f-85f1-a26a88e02225","file_path":"/Users/kaneshin/src/github.com/kaneshin/dotfiles/.claude/plans/cozy-hatching-mountain.md","reviews":1,"timestamp":1773424081}
-{"session_id":"37e723b6-37b4-4957-b889-a5410964c6c8","file_path":"/Users/kaneshin/src/github.com/kaneshin/dotfiles/.claude/plans/whimsical-nibbling-cray.md","reviews":1,"timestamp":1773424749}
-{"session_id":"dce14b9a-a509-41e9-a190-7df322201858","file_path":"/Users/kaneshin/src/github.com/kaneshin/dotfiles/.claude/plans/pure-hugging-alpaca.md","reviews":1,"timestamp":1773425753}
-{"session_id":"47d99b73-3d38-4162-943f-fe4eadb1789d","file_path":"/Users/kaneshin/src/github.com/kaneshin/dotfiles/.claude/plans/crystalline-beaming-pond.md","reviews":1,"timestamp":1773426044}
-{"session_id":"5a82cc4e-45d5-4794-baa8-e0df84a79956","file_path":"/Users/kaneshin/src/github.com/kaneshin/dotfiles/.claude/plans/memoized-cuddling-wigderson.md","reviews":3,"timestamp":1773426976}
-{"session_id":"823832c8-bcb2-49d1-b100-3d324cf4edfd","file_path":"/Users/kaneshin/src/github.com/kaneshin/dotfiles/.claude/plans/streamed-napping-knuth.md","reviews":3,"timestamp":1773447722}

--- a/bundle/.claude/hooks/plan-review.sh
+++ b/bundle/.claude/hooks/plan-review.sh
@@ -64,17 +64,17 @@ update_plan_review_file() {
       --argjson ts "$(date +%s)" \
       '{file_path: $fp, reviews: 0, timestamp: $ts}'
   else
-    # Same plan file — preserve all fields
+    # Same plan file — single atomic write, codex_thread_id conditionally included
     local reviews codex_tid
     reviews=$(echo "$PLAN_REVIEW_JSON" | jq -r '.reviews // 0')
     codex_tid=$(echo "$PLAN_REVIEW_JSON" | jq -r '.codex_thread_id // empty' 2>/dev/null)
-    if [ -n "$codex_tid" ]; then
-      state_init --arg fp "$INPUT_FILE_PATH" --argjson rev "$reviews" --argjson ts "$(date +%s)" --arg tid "$codex_tid" \
-        '{file_path: $fp, reviews: $rev, timestamp: $ts, codex_thread_id: $tid}'
-    else
-      state_init --arg fp "$INPUT_FILE_PATH" --argjson rev "$reviews" --argjson ts "$(date +%s)" \
-        '{file_path: $fp, reviews: $rev, timestamp: $ts}'
-    fi
+    state_init \
+      --arg fp "$INPUT_FILE_PATH" \
+      --argjson rev "$reviews" \
+      --argjson ts "$(date +%s)" \
+      --arg tid "${codex_tid:-}" \
+      '{file_path: $fp, reviews: $rev, timestamp: $ts}
+       + (if $tid != "" then {codex_thread_id: $tid} else {} end)'
   fi
   log "- update state: $STATE_FILE"
 }

--- a/bundle/.claude/hooks/plan-review.sh
+++ b/bundle/.claude/hooks/plan-review.sh
@@ -24,7 +24,8 @@ TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 LOG_DIR="$HOME/.claude/logs"
 [ ! -d "$LOG_DIR" ] && mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/plan-review.log"
-echo "=== $(date '+%Y-%m-%d %H:%M:%S') $HOOK_EVENT_NAME ($TOOL_NAME) hook executed ===" >> "$LOG_FILE"
+log() { echo "$1" >> "$LOG_FILE"; }
+log "=== $(date '+%Y-%m-%d %H:%M:%S') $HOOK_EVENT_NAME ($TOOL_NAME) hook executed ==="
 
 # Per-session state file
 STATE_DIR="$CLAUDE_PROJECT_DIR/.claude/plan-review"
@@ -66,7 +67,7 @@ update_plan_review_file() {
         '{file_path: $fp, reviews: $rev, timestamp: $ts}' > "$STATE_FILE"
     fi
   fi
-  echo "- update state: $STATE_FILE" >> "$LOG_FILE"
+  log "- update state: $STATE_FILE"
 }
 
 parse_codex_jsonl() {
@@ -99,7 +100,7 @@ plan_review() {
   jq -c '.reviews = (.reviews // 0) + 1' "$STATE_FILE" > "${STATE_FILE}.tmp" \
     && mv "${STATE_FILE}.tmp" "$STATE_FILE"
 
-  echo "- review plan: $file_path (attempt $((reviews + 1)))" >> "$LOG_FILE"
+  log "- review plan: $file_path (attempt $((reviews + 1)))"
 
   # Build prompt once, reuse for both exec and resume
   local prompt
@@ -120,13 +121,13 @@ If changes are needed, end with exactly: VERDICT: REVISE"
 
   local codex_output codex_rc
   if [ -n "$codex_thread_id" ]; then
-    echo "- resuming codex thread: ${codex_thread_id:0:8}..." >> "$LOG_FILE"
+    log "- resuming codex thread: ${codex_thread_id:0:8}..."
     codex_output=$(codex exec resume --json "$codex_thread_id" "$prompt") && codex_rc=0 || codex_rc=$?
     parse_codex_jsonl "$codex_output"
 
     # Retry with fresh exec if resume failed (non-zero exit OR empty text)
     if [ "$codex_rc" -ne 0 ] || [ -z "$CODEX_REVIEW_TEXT" ]; then
-      echo "- resume failed (rc=$codex_rc), retrying with fresh exec" >> "$LOG_FILE"
+      log "- resume failed (rc=$codex_rc), retrying with fresh exec"
       codex_output=$(codex exec --json -m gpt-5.4 -s read-only "$prompt") && codex_rc=0 || codex_rc=$?
       parse_codex_jsonl "$codex_output"
     fi
@@ -139,11 +140,11 @@ If changes are needed, end with exactly: VERDICT: REVISE"
   if [ "$codex_rc" -eq 0 ] && [ -n "$CODEX_REVIEW_TEXT" ] && [ -n "$CODEX_THREAD_ID" ]; then
     jq -c --arg tid "$CODEX_THREAD_ID" '.codex_thread_id = $tid' "$STATE_FILE" > "${STATE_FILE}.tmp" \
       && mv "${STATE_FILE}.tmp" "$STATE_FILE" 2>/dev/null || true
-    echo "- saved codex thread: ${CODEX_THREAD_ID:0:8}..." >> "$LOG_FILE"
+    log "- saved codex thread: ${CODEX_THREAD_ID:0:8}..."
   fi
 
   local review_results="$CODEX_REVIEW_TEXT"
-  echo "- review results: $review_results" >> "$LOG_FILE"
+  log "- review results: $review_results"
 
   if [[ "$review_results" == *"VERDICT: APPROVED"* ]]; then
     # Clear thread_id — review cycle complete, avoid stale context
@@ -165,9 +166,9 @@ If changes are needed, end with exactly: VERDICT: REVISE"
 
 # Main dispatch — errors in state management should not block the user
 if [ "$TOOL_NAME" = "ExitPlanMode" ]; then
-  plan_review || { echo "- plan_review failed, allowing exit" >> "$LOG_FILE"; }
+  plan_review || { log "- plan_review failed, allowing exit"; }
 else
-  update_plan_review_file || { echo "- update failed, continuing" >> "$LOG_FILE"; }
+  update_plan_review_file || { log "- update failed, continuing"; }
 fi
 
 exit 0

--- a/bundle/.claude/hooks/plan-review.sh
+++ b/bundle/.claude/hooks/plan-review.sh
@@ -91,6 +91,10 @@ parse_codex_jsonl() {
     | paste -sd $'\n' -)
 }
 
+codex_exec_fresh() {
+  codex exec --json -m gpt-5.4 -s read-only "$1"
+}
+
 plan_review() {
   local file_path
   file_path=$(echo "$PLAN_REVIEW_JSON" | jq -r '.file_path // empty')
@@ -136,11 +140,11 @@ If changes are needed, end with exactly: VERDICT: REVISE"
     # Retry with fresh exec if resume failed (non-zero exit OR empty text)
     if [ "$codex_rc" -ne 0 ] || [ -z "$CODEX_REVIEW_TEXT" ]; then
       log "- resume failed (rc=$codex_rc), retrying with fresh exec"
-      codex_output=$(codex exec --json -m gpt-5.4 -s read-only "$prompt") && codex_rc=0 || codex_rc=$?
+      codex_output=$(codex_exec_fresh "$prompt") && codex_rc=0 || codex_rc=$?
       parse_codex_jsonl "$codex_output"
     fi
   else
-    codex_output=$(codex exec --json -m gpt-5.4 -s read-only "$prompt") && codex_rc=0 || codex_rc=$?
+    codex_output=$(codex_exec_fresh "$prompt") && codex_rc=0 || codex_rc=$?
     parse_codex_jsonl "$codex_output"
   fi
 

--- a/bundle/.claude/hooks/plan-review.sh
+++ b/bundle/.claude/hooks/plan-review.sh
@@ -32,6 +32,15 @@ STATE_DIR="$CLAUDE_PROJECT_DIR/.claude/plan-review"
 mkdir -p "$STATE_DIR"
 STATE_FILE="$STATE_DIR/${SESSION_ID}.json"
 
+state_init() {
+  jq -n "$@" > "$STATE_FILE"
+}
+
+state_update() {
+  jq -c "$@" "$STATE_FILE" > "${STATE_FILE}.tmp" \
+    && mv "${STATE_FILE}.tmp" "$STATE_FILE" 2>/dev/null
+}
+
 if [ -f "$STATE_FILE" ]; then
   PLAN_REVIEW_JSON=$(cat "$STATE_FILE")
 else
@@ -50,21 +59,21 @@ update_plan_review_file() {
 
   if [ "$INPUT_FILE_PATH" != "$stored_file_path" ]; then
     # New plan file — full reset
-    jq -n \
+    state_init \
       --arg fp "$INPUT_FILE_PATH" \
       --argjson ts "$(date +%s)" \
-      '{file_path: $fp, reviews: 0, timestamp: $ts}' > "$STATE_FILE"
+      '{file_path: $fp, reviews: 0, timestamp: $ts}'
   else
     # Same plan file — preserve all fields
     local reviews codex_tid
     reviews=$(echo "$PLAN_REVIEW_JSON" | jq -r '.reviews // 0')
     codex_tid=$(echo "$PLAN_REVIEW_JSON" | jq -r '.codex_thread_id // empty' 2>/dev/null)
     if [ -n "$codex_tid" ]; then
-      jq -n --arg fp "$INPUT_FILE_PATH" --argjson rev "$reviews" --argjson ts "$(date +%s)" --arg tid "$codex_tid" \
-        '{file_path: $fp, reviews: $rev, timestamp: $ts, codex_thread_id: $tid}' > "$STATE_FILE"
+      state_init --arg fp "$INPUT_FILE_PATH" --argjson rev "$reviews" --argjson ts "$(date +%s)" --arg tid "$codex_tid" \
+        '{file_path: $fp, reviews: $rev, timestamp: $ts, codex_thread_id: $tid}'
     else
-      jq -n --arg fp "$INPUT_FILE_PATH" --argjson rev "$reviews" --argjson ts "$(date +%s)" \
-        '{file_path: $fp, reviews: $rev, timestamp: $ts}' > "$STATE_FILE"
+      state_init --arg fp "$INPUT_FILE_PATH" --argjson rev "$reviews" --argjson ts "$(date +%s)" \
+        '{file_path: $fp, reviews: $rev, timestamp: $ts}'
     fi
   fi
   log "- update state: $STATE_FILE"
@@ -97,8 +106,7 @@ plan_review() {
   fi
 
   # Increment reviews BEFORE codex call (counts attempts, not successes)
-  jq -c '.reviews = (.reviews // 0) + 1' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+  state_update '.reviews = (.reviews // 0) + 1'
 
   log "- review plan: $file_path (attempt $((reviews + 1)))"
 
@@ -138,8 +146,7 @@ If changes are needed, end with exactly: VERDICT: REVISE"
 
   # Persist thread_id ONLY on successful run (rc=0 AND non-empty text)
   if [ "$codex_rc" -eq 0 ] && [ -n "$CODEX_REVIEW_TEXT" ] && [ -n "$CODEX_THREAD_ID" ]; then
-    jq -c --arg tid "$CODEX_THREAD_ID" '.codex_thread_id = $tid' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-      && mv "${STATE_FILE}.tmp" "$STATE_FILE" 2>/dev/null || true
+    state_update --arg tid "$CODEX_THREAD_ID" '.codex_thread_id = $tid' || true
     log "- saved codex thread: ${CODEX_THREAD_ID:0:8}..."
   fi
 
@@ -148,8 +155,7 @@ If changes are needed, end with exactly: VERDICT: REVISE"
 
   if [[ "$review_results" == *"VERDICT: APPROVED"* ]]; then
     # Clear thread_id — review cycle complete, avoid stale context
-    jq -c 'del(.codex_thread_id)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-      && mv "${STATE_FILE}.tmp" "$STATE_FILE" 2>/dev/null || true
+    state_update 'del(.codex_thread_id)' || true
     return 0
   fi
 

--- a/tests/plan-review_test.sh
+++ b/tests/plan-review_test.sh
@@ -788,6 +788,109 @@ test_corrupted_state_resume() {
   assert_return_code 0 "$rc" "exits 0 with corrupted state during resume (fail-open)"
 }
 
+# Case 20: State mutation failure — read-only state file → fail-open (exit 0)
+test_state_mutation_failure() {
+  echo "Test 20: State mutation failure (read-only state file)..."
+  set_mock_codex_approved
+
+  local project_dir
+  project_dir=$(setup_project)
+  local session_id="sess-readonly"
+  create_state_file "$project_dir" "$session_id" "/tmp/plan.md" 0
+
+  # Make state file read-only to trigger write failure
+  local state_file="$project_dir/.claude/plan-review/${session_id}.json"
+  chmod 444 "$state_file"
+
+  local input
+  input=$(jq -nc \
+    --arg sid "$session_id" \
+    '{
+      permission_mode: "plan",
+      session_id: $sid,
+      hook_event_name: "PreToolUse",
+      tool_name: "ExitPlanMode",
+      tool_input: {}
+    }')
+
+  local rc output
+  output=$(run_plan_review "$input" "$project_dir") && rc=0 || rc=$?
+
+  # Restore permissions for cleanup
+  chmod 644 "$state_file"
+
+  assert_return_code 0 "$rc" "exits 0 when state file is read-only (fail-open)"
+}
+
+# Case 21: Atomic codex_thread_id preservation — PostToolUse same file, verify on disk
+test_atomic_thread_id_on_disk() {
+  echo "Test 21: Atomic codex_thread_id preservation on disk..."
+
+  local project_dir
+  project_dir=$(setup_project)
+  local session_id="sess-atomic-tid"
+  create_state_file "$project_dir" "$session_id" "/tmp/plan.md" 2 "atomic-thread-xyz"
+
+  local input
+  input=$(jq -nc \
+    --arg sid "$session_id" \
+    '{
+      permission_mode: "plan",
+      session_id: $sid,
+      hook_event_name: "PostToolUse",
+      tool_name: "Write",
+      tool_input: {file_path: "/tmp/plan.md"}
+    }')
+
+  local rc output
+  output=$(run_plan_review "$input" "$project_dir") && rc=0 || rc=$?
+  assert_return_code 0 "$rc" "exits 0"
+
+  # Read state file from disk immediately — verify codex_thread_id survived
+  local state_file="$project_dir/.claude/plan-review/${session_id}.json"
+  local on_disk_tid
+  on_disk_tid=$(jq -r '.codex_thread_id // "null"' "$state_file")
+  assert_equals "atomic-thread-xyz" "$on_disk_tid" \
+    "codex_thread_id on disk matches original after PostToolUse"
+
+  # Also verify the file is valid JSON (atomic write didn't corrupt it)
+  local valid_json
+  valid_json=$(jq -e '.' "$state_file" > /dev/null 2>&1 && echo yes || echo no)
+  assert_equals "yes" "$valid_json" "state file is valid JSON after update"
+}
+
+# Case 22: Log output format — verify log file contains expected header line
+test_log_output_format() {
+  echo "Test 22: Log output format..."
+  set_mock_codex_approved
+
+  local project_dir
+  project_dir=$(setup_project)
+  local session_id="sess-log-fmt"
+  create_state_file "$project_dir" "$session_id" "/tmp/plan.md" 0
+
+  local input
+  input=$(jq -nc \
+    --arg sid "$session_id" \
+    '{
+      permission_mode: "plan",
+      session_id: $sid,
+      hook_event_name: "PreToolUse",
+      tool_name: "ExitPlanMode",
+      tool_input: {}
+    }')
+
+  local rc output
+  output=$(run_plan_review "$input" "$project_dir") && rc=0 || rc=$?
+  assert_return_code 0 "$rc" "exits 0"
+
+  # Verify log file contains the expected header format
+  local log_file="$TEST_TMP_DIR/home/.claude/logs/plan-review.log"
+  local has_header
+  has_header=$(grep -qE '=== [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} PreToolUse \(ExitPlanMode\) hook executed ===' "$log_file" && echo yes || echo no)
+  assert_equals "yes" "$has_header" "log contains expected header format"
+}
+
 # =============================================================================
 # Run Tests
 # =============================================================================
@@ -816,6 +919,9 @@ test_thread_id_preserved_same_path
 test_file_path_change_resets
 test_resume_no_thread_started
 test_corrupted_state_resume
+test_state_mutation_failure
+test_atomic_thread_id_on_disk
+test_log_output_format
 
 echo ""
 echo "================================="


### PR DESCRIPTION
## Summary

- Add 3 characterization tests (state mutation failure, atomic thread_id preservation, log output format) to strengthen coverage before refactoring
- Extract `log()`, `state_init()`, `state_update()`, and `codex_exec_fresh()` helpers replacing 9 inline echo calls, 6 raw jq-redirect patterns, and 2 duplicated codex exec invocations
- Collapse Bash if/else for `codex_thread_id` into a single `state_init` call using jq's conditional object merge
- Remove obsolete `.claude/plan-review.jsonl` (replaced by per-session state files)

## Test plan

- [x] All 56 tests pass after each structural commit (`./tests/plan-review_test.sh`)
- [x] No behavioral changes — purely structural refactoring (Tidy First)
- [x] Working tree clean after all commits